### PR TITLE
set password to '\0'(NUL)

### DIFF
--- a/ptproxy.py
+++ b/ptproxy.py
@@ -132,7 +132,7 @@ def parseptline(iterable):
             if vals[0] == CFG['ptname']:
                 host, port = vals[2].split(':')
                 CFG['_ptcli'] = (
-                    socks.PROXY_TYPES[vals[1].upper()], host, int(port), True, CFG['ptargs'])
+                    socks.PROXY_TYPES[vals[1].upper()], host, int(port), True, CFG['ptargs'], '\0')
         elif kw == 'SMETHOD':
             vals = sp[1].split(' ')
             if vals[0] == CFG['ptname']:


### PR DESCRIPTION
fix bug that do not send ptargs(as username) to the Pluggable Transport

see https://github.com/gumblex/ptproxy/blob/f79bd92618e53d8cf645b86a6fb65c41f792e232/socks.py#L396
see https://github.com/Yawning/obfs4/blob/69ffcc39c63f4a9a192082da71eea6b06a1e75d7/common/socks5/rfc1929.go#L92
